### PR TITLE
Fix compiling error with const corectness

### DIFF
--- a/examples/basic_Thermostat_OnOff/basic_Thermostat_OnOff.ino
+++ b/examples/basic_Thermostat_OnOff/basic_Thermostat_OnOff.ino
@@ -82,7 +82,7 @@ void setup()
     dht.begin();
 
     double temperature = dht.readTemperature();
-    endpointThermostat.setTemperatureTarget(temperature);
+    endpointThermostat.setHeatingSetpoint(temperature);
 }
 
 void loop()
@@ -115,7 +115,7 @@ void loop()
         Serial.println();
 
         Serial.print("Temperature target: ");
-        Serial.print(endpointThermostat.getTemperatureTarget());
+        Serial.print(endpointThermostat.getHeatingSetpoint());
         Serial.print(" *C ");
         Serial.println();
 #endif

--- a/src/arduinoWrapper/ArduinoWrapper.cpp
+++ b/src/arduinoWrapper/ArduinoWrapper.cpp
@@ -151,7 +151,7 @@ void wrapperSetServer(char* ip)
     }
 }
 
-void wrapperSetCallback(void (*callback)(char*, uint8_t*, unsigned int))
+void wrapperSetCallback(void (*callback)(const char*, const uint8_t*, const unsigned int))
 {
     m_mqtt_client.setCallback(callback);
 }

--- a/src/arduinoWrapper/ArduinoWrapper.h
+++ b/src/arduinoWrapper/ArduinoWrapper.h
@@ -11,7 +11,7 @@ void wrapperSetup();
 void wrapperSetServer(IPAddress ip);
 void wrapperSetServer(uint8_t* ip);
 void wrapperSetServer(char* ip);
-void wrapperSetCallback(void (*callback)(char*, uint8_t*, unsigned int));
+void wrapperSetCallback(void (*callback)(const char*, const uint8_t*, const unsigned int));
 bool wrapperIsMqttConnected();
 void wrapperSetUsernamePassword(const char* const username, const char* const password);
 void wrapperClearMessageBuffer();


### PR DESCRIPTION
- add const keyword to make arduino/esp examples compile
- thermostat example: update deprecated TemperatureTarget to HeatingSetpoint functions